### PR TITLE
fix/number-parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-mapper",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "A CLI that adds @Map, @@Map, @updatedAt based on a json or camel case for the prisma schema",
   "main": "bin/index.js",
   "preferGlobal": true,

--- a/src/__tests__/expected.prisma
+++ b/src/__tests__/expected.prisma
@@ -18,6 +18,7 @@ model ModelOne {
   createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt DateTime? @updatedAt @map("updated_at") @db.Timestamptz(6)
   deletedAt DateTime? @map("deleted_at") @db.Timestamptz(6)
+  string    String    @default("String 1")
 
   @@index([deletedAt, someId], map: "index_name")
   @@map("model_one")

--- a/src/__tests__/mock.prisma
+++ b/src/__tests__/mock.prisma
@@ -18,6 +18,7 @@ model model_one {
   created_at DateTime  @default(now()) @db.Timestamptz(6)
   updated_at DateTime? @db.Timestamptz(6)
   deleted_at DateTime? @db.Timestamptz(6)
+  string     String    @default("String 1")
 
   @@index([deleted_at, some_id], map: "index_name")
 }

--- a/src/functions/deserialize.ts
+++ b/src/functions/deserialize.ts
@@ -59,7 +59,7 @@ const handlers = (
           .join(', ')}))`;
       }
 
-      if (typeof value === 'number' || !Number.isNaN(value)) {
+      if (typeof value === 'number' || !Number.isNaN(+value)) {
         return `@default(${value})`;
       }
 


### PR DESCRIPTION
## Change log

- Fixes an issue where the default of a string that contains a number didn't had `"`.
   e.g. `@default("String 1")` -> `@default(String 1)`